### PR TITLE
Enhance OCP node template and update configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test*
 node_joiner
 clusters_data
 common_tasks
+.DS_Store
+*.lock

--- a/roles/add-nodes-to-cluster/tasks/finish-install.yaml
+++ b/roles/add-nodes-to-cluster/tasks/finish-install.yaml
@@ -61,6 +61,29 @@
            namespace: openshift-ingress-operator
          spec:
           nodePlacement:
+            tolerations:
+            - key: node.ocs.openshift.io/storage
+              value: "true"
+              effect: NoSchedule
             nodeSelector:
               matchLabels:
                 node-role.kubernetes.io/infra: ""
+
+    - name: "Add toleration to dnses operator"
+      environment:
+       KUBECONFIG: "{{ cluster_data_dir }}/install-dir/auth/kubeconfig"
+      kubernetes.core.k8s:
+        state: patched
+        merge_type: merge
+        definition:
+          apiVersion: operator.openshift.io/v1
+          kind: DNS
+          metadata:
+            name: default
+            namespace: openshift-dns-operator
+          spec:
+            nodePlacement:
+              tolerations:
+              - key: node.ocs.openshift.io/storage
+                value: "true"
+                effect: NoSchedule

--- a/roles/deploy-vms/templates/ocp-node.j2
+++ b/roles/deploy-vms/templates/ocp-node.j2
@@ -21,7 +21,24 @@ spec:
               storage: "{{ item.disk_size_gb }}Gi"
           storageClassName: {{ ovirt.storage_class }}
   template:
+    metadata:
+      annotations:
+        descheduler.alpha.kubernetes.io/evict: 'true'
+      labels:
+        antiaffinity: {{ config.cluster_name }}-{{ item.role }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: antiaffinity
+                  operator: In
+                  values:
+                  - {{ config.cluster_name }}-{{ item.role }}
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       evictionStrategy: LiveMigrateIfPossible
       architecture: amd64
       domain:

--- a/roles/odf/tasks/install/localstorage.yml
+++ b/roles/odf/tasks/install/localstorage.yml
@@ -84,8 +84,8 @@
       kind: Node
       metadata:
         name: "{{ item.name }}.{{ config.cluster_name }}.{{ config.base_domain }}"
-        labels: 
-          cluster.ocs.openshift.io/openshift-storage: ""    
+        labels:
+          cluster.ocs.openshift.io/openshift-storage: ""
     # kubeconfig: "{{ kubeconfig }}"
   loop: "{{ odf_nodes }}"
 

--- a/roles/odf/templates/localstorage/localvolume.yaml
+++ b/roles/odf/templates/localstorage/localvolume.yaml
@@ -5,6 +5,11 @@ metadata:
   name: local-block
   namespace: openshift-local-storage
 spec:
+  tolerations:
+  - key: node.ocs.openshift.io/storage
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
   nodeSelector:
     nodeSelectorTerms:
       - matchExpressions:

--- a/roles/prereqs/tasks/validate-config.yaml
+++ b/roles/prereqs/tasks/validate-config.yaml
@@ -36,7 +36,7 @@
       {%- for key, value in nodes.items() -%}
         {%- set updated_list = [] -%}
         {%- for item in value -%}
-          {%- set _ = updated_list.append(item | combine({'name': key ~ loop.index })) -%}
+          {%- set _ = updated_list.append(item | combine({'name': key ~ loop.index, 'role': key })) -%}
         {%- endfor -%}
         {%- set _ = updated_nodes.update({key: updated_list}) -%}
       {%- endfor -%}


### PR DESCRIPTION
Improve the OCP node template with pod anti-affinity, annotations, and tolerations for storage. Update the .gitignore file to include common files and enhance node role assignment validation.